### PR TITLE
Php7

### DIFF
--- a/src/Collection/ImmArray.php
+++ b/src/Collection/ImmArray.php
@@ -158,13 +158,13 @@ class ImmArray implements Iterator, ArrayAccess, Countable, JsonSerializable
     /**
      * Concat to the end of this array
      *
-     * @param ImmArray,...
+     * @param ImmArray,... $ias One or more immutable array to concat to end
      * @return ImmArray
      */
-    public function concat(ImmArray ...$args): self
+    public function concat(ImmArray ...$ias): self
     {
         // Create as new immutable's iterator
-        return new static(new ConcatIterator($this, ...$args));
+        return new static(new ConcatIterator($this, ...$ias));
     }
 
     /**
@@ -206,12 +206,18 @@ class ImmArray implements Iterator, ArrayAccess, Countable, JsonSerializable
      */
     public static function fromItems(Traversable $arr): self
     {
-        $sfa = new SplFixedArray(count($arr));
-        foreach ($arr as $i => $el) {
-            $sfa[$i] = $el;
-        }
+        // Easiest if we know the size of the traversable upfront
+        if ($arr instanceof Countable) {
+            $sfa = new SplFixedArray(count($arr));
+            foreach ($arr as $i => $el) {
+                $sfa[$i] = $el;
+            }
 
-        return new static($sfa);
+            return new static($sfa);
+        } else {
+            // We don't know the size, so we'll need to load from array
+            return static::fromArray(iterator_to_array($arr));
+        }
     }
 
     /**

--- a/src/Iterator/ConcatIterator.php
+++ b/src/Iterator/ConcatIterator.php
@@ -26,10 +26,10 @@ class ConcatIterator extends AppendIterator implements ArrayAccess, Countable, J
      *
      * @param Iterator $iterator,... Concat iterators in order
      */
-    public function __construct()
+    public function __construct(Iterator ...$iterators)
     {
         parent::__construct();
-        foreach (func_get_args() as $i => $iterator) {
+        foreach ($iterators as $i => $iterator) {
             if (
                 $iterator instanceof ArrayAccess &&
                 $iterator instanceof Countable
@@ -57,7 +57,7 @@ class ConcatIterator extends AppendIterator implements ArrayAccess, Countable, J
     /**
      * Countable
      */
-    public function count()
+    public function count(): int
     {
         return $this->count;
     }
@@ -65,7 +65,7 @@ class ConcatIterator extends AppendIterator implements ArrayAccess, Countable, J
     /**
      * ArrayAccess
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return $offset >= 0 && $offset < $this->count;
     }
@@ -95,12 +95,12 @@ class ConcatIterator extends AppendIterator implements ArrayAccess, Countable, J
     /**
      * JsonSerializable
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         return iterator_to_array($this, false);
     }


### PR DESCRIPTION
Cleans out the reflection and function arg fiddling that php5.6 needed, and replaces with clean 7.1 code. Adds much stricter type hints on the method returns.